### PR TITLE
Add runnable polling bot scaffold

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -1,0 +1,6 @@
+"""Runtime package for the concierge bot."""
+
+from .config import Settings
+from .app import BotApp, main
+
+__all__ = ["Settings", "BotApp", "main"]

--- a/bot/app.py
+++ b/bot/app.py
@@ -1,0 +1,142 @@
+"""Telegram-like bot runtime utilities."""
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Optional
+from urllib import error, parse, request
+
+from .config import Settings
+
+API_BASE = "https://api.telegram.org"
+
+
+@dataclass(slots=True)
+class BotApp:
+    """Simple long-polling bot implementation."""
+
+    settings: Settings
+
+    def __post_init__(self) -> None:
+        self._base_url = f"{API_BASE}/bot{self.settings.token}"
+        self._logger = logging.getLogger("bot")
+
+    # ------------------------------------------------------------------
+    # Network helpers
+    # ------------------------------------------------------------------
+    def _api_call(self, method: str, **params: Any) -> Dict[str, Any]:
+        """Perform an API call against the Telegram HTTP interface."""
+
+        query = parse.urlencode({k: v for k, v in params.items() if v is not None})
+        url = f"{self._base_url}/{method}"
+        if query:
+            url = f"{url}?{query}"
+
+        req = request.Request(url)
+        try:
+            with request.urlopen(req, timeout=self.settings.request_timeout) as resp:
+                payload = resp.read().decode("utf-8")
+                return json.loads(payload)
+        except error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"HTTP error {exc.code} calling {method}: {detail}") from exc
+        except error.URLError as exc:  # pragma: no cover - defensive network guard
+            raise RuntimeError(f"Failed to reach API for {method}: {exc.reason}") from exc
+
+    # ------------------------------------------------------------------
+    # High-level operations
+    # ------------------------------------------------------------------
+    def get_updates(self, offset: Optional[int] = None) -> Dict[str, Any]:
+        """Fetch new updates from the Telegram API."""
+
+        return self._api_call(
+            "getUpdates",
+            offset=offset,
+            timeout=self.settings.request_timeout,
+        )
+
+    def send_message(self, chat_id: int, text: str) -> Dict[str, Any]:
+        """Send a message to the given chat."""
+
+        return self._api_call("sendMessage", chat_id=chat_id, text=text)
+
+    # ------------------------------------------------------------------
+    # Update processing
+    # ------------------------------------------------------------------
+    def handle_update(self, update: Dict[str, Any]) -> None:
+        """Handle a single update payload."""
+
+        message = update.get("message")
+        if not message:
+            return
+
+        chat = message.get("chat") or {}
+        chat_id = chat.get("id")
+        if chat_id is None:
+            self._logger.debug("Skipping message without chat id: %s", update)
+            return
+
+        text = message.get("text")
+        if text:
+            reply = f"Echo: {text}"
+        else:
+            reply = "I can only echo text messages right now."
+
+        self._logger.info("Replying to chat %s", chat_id)
+        self.send_message(chat_id=chat_id, text=reply)
+
+    def process_updates(self, updates: Iterable[Dict[str, Any]]) -> None:
+        for update in updates:
+            try:
+                self.handle_update(update)
+            except Exception as exc:  # pragma: no cover - defensive code
+                self._logger.exception("Error while handling update: %s", exc)
+
+    # ------------------------------------------------------------------
+    # Main loop
+    # ------------------------------------------------------------------
+    def run(self) -> None:
+        """Start the long-polling loop."""
+
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+        )
+        self._logger.info("Bot is starting with polling interval %s seconds.", self.settings.check_interval)
+
+        offset: Optional[int] = None
+        while True:
+            try:
+                response = self.get_updates(offset)
+            except Exception as exc:
+                self._logger.error("Failed to fetch updates: %s", exc)
+                time.sleep(self.settings.check_interval)
+                continue
+
+            if not response.get("ok", False):
+                description = response.get("description", "unknown error")
+                self._logger.error("API returned failure: %s", description)
+                time.sleep(self.settings.check_interval)
+                continue
+
+            updates = response.get("result", [])
+            if updates:
+                offset = updates[-1]["update_id"] + 1
+                self.process_updates(updates)
+            else:
+                self._logger.debug("No updates received.")
+
+            time.sleep(self.settings.check_interval)
+
+
+def main() -> None:
+    """Entrypoint used by ``python -m bot``."""
+
+    settings = Settings.from_env()
+    BotApp(settings=settings).run()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI hook
+    main()

--- a/bot/config.py
+++ b/bot/config.py
@@ -1,0 +1,87 @@
+"""Configuration utilities for the bot service."""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Optional
+
+DEFAULT_DATABASE_PATH: Path = Path("data/bot.sqlite3")
+DEFAULT_CHECK_INTERVAL: int = 30
+DEFAULT_REQUEST_TIMEOUT: int = 10
+
+ENV_DATABASE_PATH = "BOT_DATABASE_PATH"
+ENV_CHECK_INTERVAL = "BOT_CHECK_INTERVAL"
+ENV_REQUEST_TIMEOUT = "BOT_REQUEST_TIMEOUT"
+ENV_TOKEN = "BOT_TOKEN"
+
+
+def _parse_int(name: str, raw_value: Optional[str], default: int) -> int:
+    """Parse an integer environment variable with friendly errors.
+
+    Parameters
+    ----------
+    name:
+        The name of the environment variable.
+    raw_value:
+        The string value fetched from the environment, if any.
+    default:
+        The fallback value when ``raw_value`` is empty.
+
+    Returns
+    -------
+    int
+        The parsed integer or ``default`` when ``raw_value`` is not provided.
+
+    Raises
+    ------
+    ValueError
+        If ``raw_value`` is not a valid integer string.
+    """
+
+    if raw_value in (None, ""):
+        return default
+
+    try:
+        return int(raw_value)
+    except ValueError as exc:  # pragma: no cover - defensive code
+        raise ValueError(f"{name} must be an integer, got {raw_value!r}") from exc
+
+
+@dataclass(slots=True)
+class Settings:
+    """Runtime settings for the bot service."""
+
+    token: str
+    database_path: Path
+    check_interval: int
+    request_timeout: int
+
+    @classmethod
+    def from_env(cls, environ: Optional[Mapping[str, str]] = None) -> "Settings":
+        """Create a :class:`Settings` instance populated from the environment."""
+
+        env = dict(os.environ if environ is None else environ)
+
+        token = env.get(ENV_TOKEN, "").strip()
+        if not token:
+            raise RuntimeError(
+                f"Missing bot token. Please set the {ENV_TOKEN} environment variable."
+            )
+
+        raw_database_path = env.get(ENV_DATABASE_PATH, "").strip()
+        database_path = Path(raw_database_path) if raw_database_path else DEFAULT_DATABASE_PATH
+
+        check_interval = _parse_int(
+            ENV_CHECK_INTERVAL, env.get(ENV_CHECK_INTERVAL), DEFAULT_CHECK_INTERVAL
+        )
+        request_timeout = _parse_int(
+            ENV_REQUEST_TIMEOUT, env.get(ENV_REQUEST_TIMEOUT), DEFAULT_REQUEST_TIMEOUT
+        )
+
+        return cls(
+            token=token,
+            database_path=database_path,
+            check_interval=check_interval,
+            request_timeout=request_timeout,
+        )


### PR DESCRIPTION
## Summary
- require an explicit bot token in the runtime settings and expose environment names as constants
- add a long-polling BotApp that echoes messages through the Telegram HTTP API with a ``python -m bot`` entrypoint
- export the primary runtime helpers from the package root for easier imports

## Testing
- python -m compileall bot

------
https://chatgpt.com/codex/tasks/task_e_68e0e7cc475c832ab5932b7c85b98c1c